### PR TITLE
fix: add name, description and attribution option for tippecanoe

### DIFF
--- a/ingest/config.py
+++ b/ingest/config.py
@@ -12,6 +12,8 @@ logging.basicConfig(
 raw_folder = "raw"
 datasets_folder = "datasets"
 
+attribution = "United Nations Development Programme (UNDP)"
+
 # account_url = os.getenv("ACCOUNT_URL")
 # assert account_url is not None, f"ACCOUNT_URL env var is not set"
 # container_name = os.getenv("CONTAINER_NAME")

--- a/ingest/processing.py
+++ b/ingest/processing.py
@@ -6,7 +6,7 @@ from osgeo import gdal, osr, ogr
 from pmtiles.reader import Reader, MmapSource
 import typing
 import tempfile
-from ingest.config import gdal_configs
+from ingest.config import gdal_configs, attribution
 from rio_cogeo import cog_validate
 
 import logging
@@ -198,6 +198,9 @@ def fgb2pmtiles(blob_url=None, fgb_layers: typing.Dict[str, str] = None, pmtiles
                     "--no-tile-size-limit",
                     "--no-tile-compression",
                     "--force",
+                    f'--name={layer_name}',
+                    f'--description={layer_name}',
+                    f'--attribution={attribution}',
                     fgb_layer_path,
                 ]
                 tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
@@ -264,7 +267,9 @@ def fgb2pmtiles(blob_url=None, fgb_layers: typing.Dict[str, str] = None, pmtiles
                 "--no-tile-size-limit",
                 "--no-tile-compression",
                 "--force",
-
+                f'--name={pmtiles_file_name}',
+                f'--description={pmtiles_file_name}',
+                f'--attribution={attribution}',
             ]
 
             tippecanoe_cmd += fgb_sources


### PR DESCRIPTION
closes #3 

@iferencik Please review it for me. I added UNDP's attribution as default. For name and description, use `layer_name` if single layer pmtiles, if multiple layers, use pmtiles file name.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1201954190) by [Unito](https://www.unito.io)
