### PR TITLE
fix: use specific gdal docker image of 3.8.5 since the latest one has issue of building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 .git
+Pipfile
+Pipfile.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .git
 Pipfile
 Pipfile.lock
+.github/
+dockerfiles/
+venv/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN make
 
 # Build production docker image
 # add "--platform=linux/amd64" for M1 Mac
-FROM ghcr.io/osgeo/gdal:ubuntu-small-latest
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.5
 
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
I encountered the below error when I build docker image with the latest `ghcr.io/osgeo/gdal:ubuntu-small-latest`. I found there is this issue after 3.9.0 gdal docker image. Instead of using the latest, I added specific image version of 3.8.5 which can work in the current data pipeline.

Furthermore, I added unnecessary files and folders for Docker in .dockerignore file. 

```shell
12.55 error: externally-managed-environment
12.55 
12.55 × This environment is externally managed
12.55 ╰─> To install Python packages system-wide, try apt install
12.55     python3-xyz, where xyz is the package you are trying to
12.55     install.
12.55     
12.55     If you wish to install a non-Debian-packaged Python package,
12.55     create a virtual environment using python3 -m venv path/to/venv.
12.55     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
12.55     sure you have python3-full installed.
12.55     
12.55     If you wish to install a non-Debian packaged Python application,
12.55     it may be easiest to use pipx install xyz, which will manage a
12.55     virtual environment for you. Make sure you have pipx installed.
12.55     
12.55     See /usr/share/doc/python3.12/README.venv for more information.
12.55 
12.55 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
12.55 hint: See PEP 668 for the detailed specification.
------
failed to solve: process "/bin/sh -c apt-get update   && apt-get install -y --no-install-recommends   libffi-dev python3-pip   && rm -rf /var/lib/apt/lists/*   && pip3 install --no-cache-dir -r requirements.txt" did not complete successfully: exit code: 1
```