### PR TITLE
chore: updated dependencies and downgraded some of modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 azure_storage_blob==12.23.1
-fastapi==0.92.0 
-rasterio==1.3.6
-rio_cogeo==3.5.2 
-uvicorn==0.20.0
-aiohttp==3.10.2
-azure-servicebus==7.12.3
+rasterio==1.4.1
+rio_cogeo==4.0.1
+aiohttp==3.10.8
+azure-servicebus==7.8.2
 pmtiles==3.4.0
 aiofile==3.8.8
 azure-messaging-webpubsubclient==1.1.0


### PR DESCRIPTION
- removed unused `fastapi` and `uviconrn`
- downgraded `azure-servicebus`. this have to stay at 7.8.2
- upgraded `rio_cogeo` to v4. this cannot be upgraded to v5
- updated `rasterio` to the latest