### PR TITLE
fix: downgrade ubuntu to 22 for tippecanoe build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build felt/tippecanoe
 # Dockerfile from https://github.com/felt/tippecanoe/blob/main/Dockerfile
 # add "--platform=linux/x86_64" for M1 Mac
-FROM ubuntu:24.04 AS tippecanoe-builder
+FROM ubuntu:22.04 AS tippecanoe-builder
 
 RUN apt-get update \
   && apt-get -y install build-essential libsqlite3-dev zlib1g-dev git
@@ -22,7 +22,7 @@ WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-  libffi-dev python3-pip \
+  libffi-dev python3-pip libsqlite3-0 \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
there is an error of tippecanoe when build it with ubuntu 24.

```shell
Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
There could be issues with layer "Office_point".
Original number of features/geometries =606 while converted=605Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
There could be issues with layer "Office".
Original number of features/geometries =606 while converted=605Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
Traceback (most recent call last):
  File "/usr/src/app/ingest/processing.py", line 245, in fgb2pmtiles
    tippecanoe(tippecanoe_cmd=tippecanoe_cmd, timeout_event=timeout_event)
  File "/usr/src/app/ingest/processing.py", line 94, in tippecanoe
    raise Exception(err)
Exception: tippecanoe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by tippecanoe)
```